### PR TITLE
Fixed crashing on discord restart

### DIFF
--- a/VoiceActivity/VoiceActivity.plugin.js
+++ b/VoiceActivity/VoiceActivity.plugin.js
@@ -1,7 +1,7 @@
 /**
  * @name VoiceActivity
  * @author Neodymium
- * @version 1.1.2
+ * @version 1.1.3
  * @description Shows icons on the member list and info in User Popouts when somemone is in a voice channel.
  * @source https://github.com/Neodymium7/BetterDiscordStuff/blob/main/VoiceActivity/VoiceActivity.plugin.js
  * @updateUrl https://raw.githubusercontent.com/Neodymium7/BetterDiscordStuff/main/VoiceActivity/VoiceActivity.plugin.js
@@ -40,13 +40,13 @@ module.exports = (() => {
                     "name": "Neodymium"
                 }
             ],
-            "version": "1.1.2",
+            "version": "1.1.3",
             "description": "Shows icons on the member list and info in User Popouts when somemone is in a voice channel.",
             "github": "https://github.com/Neodymium7/BetterDiscordStuff/blob/main/VoiceActivity/VoiceActivity.plugin.js",
             "github_raw": "https://raw.githubusercontent.com/Neodymium7/BetterDiscordStuff/main/VoiceActivity/VoiceActivity.plugin.js"
         },
         "changelog": [
-            {"title": "Fixed", "type": "fixed", "items": ["Fixed crashing in private calls"]},
+            {"title": "Fixed", "type": "fixed", "items": ["Fixed crashing in private calls", "Fixed crashing on discord restart"]},
         ],
         "main": "index.js"
     };
@@ -126,7 +126,7 @@ module.exports = (() => {
                 if (!channel) return null;
                 const guild = GuildStore.getGuild(channel.guild_id);
                 
-                const showHiddenUsers = BdApi.Plugins.isEnabled("ShowHiddenChannels") && getSHCBlacklist && !getSHCBlacklist().includes(guild?.id) && BdApi.Plugins.get("ShowHiddenChannels").instance.settings.general.showVoiceUsers;
+                const showHiddenUsers = BdApi.Plugins.isEnabled("ShowHiddenChannels") && getSHCBlacklist && !getSHCBlacklist().includes(guild?.id) && BdApi.Plugins.get("ShowHiddenChannels").instance.settings?.general.showVoiceUsers;
                 if (guild && !showHiddenUsers && !Permissions.can({permission: DiscordPermissions.VIEW_CHANNEL, user: UserStore.getCurrentUser(), context: channel})) return null;
                 if (props.settings.ignore.enabled && (props.settings.ignore.channels.includes(channel.id) || props.settings.ignore.guilds.includes(guild?.id))) return null;
 

--- a/VoiceActivity/VoiceActivity.plugin.js
+++ b/VoiceActivity/VoiceActivity.plugin.js
@@ -201,7 +201,7 @@ module.exports = (() => {
                 if (!channel) return null;
                 const guild = GuildStore.getGuild(channel.guild_id);
 
-                const showHiddenUsers = BdApi.Plugins.isEnabled("ShowHiddenChannels") && getSHCBlacklist && !getSHCBlacklist().includes(guild?.id) && BdApi.Plugins.get("ShowHiddenChannels").instance.settings.general.showVoiceUsers;
+                const showHiddenUsers = BdApi.Plugins.isEnabled("ShowHiddenChannels") && getSHCBlacklist && !getSHCBlacklist().includes(guild?.id) && BdApi.Plugins.get("ShowHiddenChannels").instance.settings?.general.showVoiceUsers;
                 if (guild && !showHiddenUsers && !Permissions.can({permission: DiscordPermissions.VIEW_CHANNEL, user: UserStore.getCurrentUser(), context: channel})) return null;
                 if (props.settings.ignore.enabled && (props.settings.ignore.channels.includes(channel.id) || props.settings.ignore.guilds.includes(guild?.id))) return null;
 


### PR DESCRIPTION
There was a bug that caused discord to crash on restart if you were already in a voice channel.
This was caused if you have the "ShowHiddenChannels" plugin enabled and you are already in a voice channel on restart.
I have fixed that bug.