### PR TITLE
feat: Lookup Song on Youtube on icon click

### DIFF
--- a/ActivityIcons/ActivityIcons.plugin.js
+++ b/ActivityIcons/ActivityIcons.plugin.js
@@ -294,7 +294,14 @@ function buildPlugin([BasePlugin, Library]) {
 			}, BdApi.React.createElement(Headset, {
 				className: "activity-icon-small",
 				width: "14",
-				height: "14"
+				height: "14",
+				onClick: (e) => {
+					e.stopPropagation();
+					const song = activity.details;
+					const artist = activity.state.replace(/;/g, " ");
+					const url = `https://www.youtube.com/results?search_query=${artist}+-+${song}`;
+					window.open(url, "_blank", "noopener,noreferrer");
+				}
 			})));
 		}
 	


### PR DESCRIPTION
A feature that allows users to search for a song that a friend is listening to on Youtube by simply clicking on the headphones icon next to the friend's username.